### PR TITLE
Upgrade to terraform-plugin-framework@v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/hashicorp-demoapp/hashicups-client-go v0.0.0-20210721190446-1df90c457bd4
-	github.com/hashicorp/terraform-plugin-framework v0.3.0
+	github.com/hashicorp/terraform-plugin-framework v0.4.1
+	github.com/hashicorp/terraform-plugin-go v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -36,10 +36,10 @@ github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd h1:rNuUHR+CvK1I
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-plugin v1.3.0 h1:4d/wJojzvHV1I4i/rrjVaeuyxWrLzDE1mDCyDy8fXS8=
 github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
-github.com/hashicorp/terraform-plugin-framework v0.3.0 h1:gdEwwwC09h1z/5PP3LSpAGw9YFIUG9JSoK6agG2reoo=
-github.com/hashicorp/terraform-plugin-framework v0.3.0/go.mod h1:9pDOoxcGdAKOjDWUpa+QOpj2npeJvgf4imnwYBTwIq8=
-github.com/hashicorp/terraform-plugin-go v0.3.1 h1:ML+THFcqpdR049gqrbEFDFo99va2Wqw9g4XDPy51euU=
-github.com/hashicorp/terraform-plugin-go v0.3.1/go.mod h1:dFHsQMaTLpON2gWhVWT96fvtlc/MF1vSy3OdMhWBzdM=
+github.com/hashicorp/terraform-plugin-framework v0.4.1 h1:ns13hZg4OFhBUesrZXG5WLi6TYuI5EolfpdEyGNvv4M=
+github.com/hashicorp/terraform-plugin-framework v0.4.1/go.mod h1:rV7pWcX0+tpDLQFl0XuF2SGO1fm8JkVytduSu/HbIbY=
+github.com/hashicorp/terraform-plugin-go v0.4.0 h1:LFbXNeLDo0J/wR0kUzSPq0RpdmFh2gNedzU0n/gzPAo=
+github.com/hashicorp/terraform-plugin-go v0.4.0/go.mod h1:7u/6nt6vaiwcWE2GuJKbJwNlDFnf5n95xKw4hqIVr58=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=

--- a/hashicups/resource_order.go
+++ b/hashicups/resource_order.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 type resourceOrderType struct{}
@@ -297,4 +298,10 @@ func (r resourceOrder) Delete(ctx context.Context, req tfsdk.DeleteResourceReque
 
 	// Remove resource from state
 	resp.State.RemoveResource(ctx)
+}
+
+// Import resource
+func (r resourceOrder) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+	// Save the import identifier in the id attribute
+	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
 }


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-framework/issues/156

Updated via:

```
go get github.com/hashicorp/terraform-plugin-framework@v0.4.1
go mod tidy
```

Along with adding the now required `ImportState` method implementation for `Resource`. This implementation opts to support import by passing through the import identifier into the `id` attribute, however `tfsdk.ResourceImportStateNotImplemented()` could also be used to signal this resource does not (yet) support import if separately setting up that tutorial is desired.