### PR TITLE
Add new datasource, update func, update to 0.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/hashicorp-demoapp/hashicups-client-go v0.0.0-20210721190446-1df90c457bd4
-	github.com/hashicorp/terraform-plugin-framework v0.4.1
+	github.com/hashicorp/terraform-plugin-framework v0.4.2
 	github.com/hashicorp/terraform-plugin-go v0.4.0
+
 )

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd h1:rNuUHR+CvK1I
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-plugin v1.3.0 h1:4d/wJojzvHV1I4i/rrjVaeuyxWrLzDE1mDCyDy8fXS8=
 github.com/hashicorp/go-plugin v1.3.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
-github.com/hashicorp/terraform-plugin-framework v0.4.1 h1:ns13hZg4OFhBUesrZXG5WLi6TYuI5EolfpdEyGNvv4M=
-github.com/hashicorp/terraform-plugin-framework v0.4.1/go.mod h1:rV7pWcX0+tpDLQFl0XuF2SGO1fm8JkVytduSu/HbIbY=
+github.com/hashicorp/terraform-plugin-framework v0.4.2 h1:XcvBN5qpEMddstbmfN8UYZ+ON4kb9G9CkyaiHsLVn7A=
+github.com/hashicorp/terraform-plugin-framework v0.4.2/go.mod h1:rV7pWcX0+tpDLQFl0XuF2SGO1fm8JkVytduSu/HbIbY=
 github.com/hashicorp/terraform-plugin-go v0.4.0 h1:LFbXNeLDo0J/wR0kUzSPq0RpdmFh2gNedzU0n/gzPAo=
 github.com/hashicorp/terraform-plugin-go v0.4.0/go.mod h1:7u/6nt6vaiwcWE2GuJKbJwNlDFnf5n95xKw4hqIVr58=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=

--- a/hashicups/data_source_order.go
+++ b/hashicups/data_source_order.go
@@ -1,0 +1,128 @@
+package hashicups
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type dataSourceOrderType struct{}
+
+func (r dataSourceOrderType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
+	return tfsdk.Schema{
+		Attributes: map[string]tfsdk.Attribute{
+			"id": {
+				Type: types.StringType,
+				// When Computed is true, the provider will set value --
+				// the user cannot define the value
+				Required: true,
+			},
+			"last_updated": {
+				Type:     types.StringType,
+				Computed: true,
+			},
+			"items": {
+				// If Required is true, Terraform will throw error if user
+				// doesn't specify value
+				// If Optional is true, user can choose to supply a value
+				Computed: true,
+				Attributes: tfsdk.ListNestedAttributes(map[string]tfsdk.Attribute{
+					"quantity": {
+						Type:     types.NumberType,
+						Computed: true,
+					},
+					"coffee": {
+						Computed: true,
+						Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
+							"id": {
+								Type:     types.NumberType,
+								Required: true,
+							},
+							"name": {
+								Type:     types.StringType,
+								Computed: true,
+							},
+							"teaser": {
+								Type:     types.StringType,
+								Computed: true,
+							},
+							"description": {
+								Type:     types.StringType,
+								Computed: true,
+							},
+							"price": {
+								Type:     types.NumberType,
+								Computed: true,
+							},
+							"image": {
+								Type:     types.StringType,
+								Computed: true,
+							},
+						}),
+					},
+				}, tfsdk.ListNestedAttributesOptions{}),
+			},
+		},
+	}, nil
+}
+
+func (r dataSourceOrderType) NewDataSource(ctx context.Context, p tfsdk.Provider) (tfsdk.DataSource, diag.Diagnostics) {
+	return dataSourceOrder{
+		p: *(p.(*provider)),
+	}, nil
+}
+
+type dataSourceOrder struct {
+	p provider
+}
+
+func (r dataSourceOrder) Read(ctx context.Context, req tfsdk.ReadDataSourceRequest, resp *tfsdk.ReadDataSourceResponse) {
+
+	// Declare struct that this function will set to this data source's state
+
+	var resourceData Order
+	diags := req.Config.Get(ctx, &resourceData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get order from API and then update what is in state from what the API returns
+	orderID := resourceData.ID.Value
+
+	// Get order current value
+	order, err := r.p.client.GetOrder(orderID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error retrieving order",
+			err.Error(),
+		)
+		return
+	}
+
+	// Map response body to resource schema attribute
+	resourceData.Items = []OrderItem{}
+	for _, item := range order.Items {
+		resourceData.Items = append(resourceData.Items, OrderItem{
+			Coffee: Coffee{
+				ID:          item.Coffee.ID,
+				Name:        types.String{Value: item.Coffee.Name},
+				Teaser:      types.String{Value: item.Coffee.Teaser},
+				Description: types.String{Value: item.Coffee.Description},
+				Price:       types.Number{Value: big.NewFloat(item.Coffee.Price)},
+				Image:       types.String{Value: item.Coffee.Image},
+			},
+			Quantity: item.Quantity,
+		})
+	}
+
+	// Set state
+	diags = resp.State.Set(ctx, &resourceData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}

--- a/hashicups/provider.go
+++ b/hashicups/provider.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/hashicorp-demoapp/hashicups-client-go"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -141,6 +142,7 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 
 	// Create a new HashiCups client and set it to the provider client
 	c, err := hashicups.NewClient(&host, &username, &password)
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable to create client",
@@ -164,5 +166,6 @@ func (p *provider) GetResources(_ context.Context) (map[string]tfsdk.ResourceTyp
 func (p *provider) GetDataSources(_ context.Context) (map[string]tfsdk.DataSourceType, diag.Diagnostics) {
 	return map[string]tfsdk.DataSourceType{
 		"hashicups_coffees": dataSourceCoffeesType{},
+		"hashicups_order":   dataSourceOrderType{},
 	}, nil
 }

--- a/hashicups/resource_order.go
+++ b/hashicups/resource_order.go
@@ -289,6 +289,28 @@ func (r resourceOrder) Update(ctx context.Context, req tfsdk.UpdateResourceReque
 
 // Delete resource
 func (r resourceOrder) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+	var state Order
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get order ID from state
+	orderID := state.ID.Value
+
+	// Delete order by calling API
+	err := r.p.client.DeleteOrder(orderID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting order",
+			"Could not delete orderID "+orderID+": "+err.Error(),
+		)
+		return
+	}
+
+	// Remove resource from state
+	resp.State.RemoveResource(ctx)
 }
 
 // Import resource

--- a/hashicups/resource_order.go
+++ b/hashicups/resource_order.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	"github.com/hashicorp-demoapp/hashicups-client-go"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	//
 )
 
 type resourceOrderType struct{}
@@ -203,7 +205,8 @@ func (r resourceOrder) Read(ctx context.Context, req tfsdk.ReadResourceRequest, 
 
 // Update resource
 func (r resourceOrder) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
-	// Get plan values
+
+	// Retrieve the changes proposed in the execution plan
 	var plan Order
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -211,7 +214,7 @@ func (r resourceOrder) Update(ctx context.Context, req tfsdk.UpdateResourceReque
 		return
 	}
 
-	// Get current state
+	// Retrieve the current state values
 	var state Order
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -219,7 +222,7 @@ func (r resourceOrder) Update(ctx context.Context, req tfsdk.UpdateResourceReque
 		return
 	}
 
-	// Generate API request body from plan
+	// Retrieve the item changes from the proposed plan
 	var items []hashicups.OrderItem
 	for _, item := range plan.Items {
 		items = append(items, hashicups.OrderItem{
@@ -230,11 +233,11 @@ func (r resourceOrder) Update(ctx context.Context, req tfsdk.UpdateResourceReque
 		})
 	}
 
-	// Get order ID from state
+	// Retrieve the current ID of the order to be updated from the state file
 	orderID := state.ID.Value
 
-	// Update order by calling API
-	order, err := r.p.client.UpdateOrder(orderID, items)
+	// Call the update function to retrieve the items. Discard the value of the #TODO...
+	_, err := r.p.client.UpdateOrder(orderID, items)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error update order",
@@ -243,7 +246,17 @@ func (r resourceOrder) Update(ctx context.Context, req tfsdk.UpdateResourceReque
 		return
 	}
 
-	// Map response body to resource schema attribute
+	// Retrieve the order ID information from the API
+	order, err := r.p.client.GetOrder(orderID)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error reading order",
+			"Could not read orderID "+orderID+": "+err.Error(),
+		)
+		return
+	}
+
+	// Retrieve the order response based on the orderID changes from the `GetOrder` client function
 	var ois []OrderItem
 	for _, oi := range order.Items {
 		ois = append(ois, OrderItem{
@@ -259,14 +272,14 @@ func (r resourceOrder) Update(ctx context.Context, req tfsdk.UpdateResourceReque
 		})
 	}
 
-	// Generate resource state struct
-	var result = Order{
+	// Wrap the results from the order in the Terraform schema with the items and new computed values
+	result := Order{
 		ID:          types.String{Value: strconv.Itoa(order.ID)},
 		Items:       ois,
 		LastUpdated: types.String{Value: string(time.Now().Format(time.RFC850))},
 	}
 
-	// Set state
+	// Write the response result variable to state
 	diags = resp.State.Set(ctx, result)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -276,28 +289,6 @@ func (r resourceOrder) Update(ctx context.Context, req tfsdk.UpdateResourceReque
 
 // Delete resource
 func (r resourceOrder) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
-	var state Order
-	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Get order ID from state
-	orderID := state.ID.Value
-
-	// Delete order by calling API
-	err := r.p.client.DeleteOrder(orderID)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting order",
-			"Could not delete orderID "+orderID+": "+err.Error(),
-		)
-		return
-	}
-
-	// Remove resource from state
-	resp.State.RemoveResource(ctx)
 }
 
 // Import resource

--- a/main.go
+++ b/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"terraform-provider-hashicups-pf/hashicups"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
 
 func main() {


### PR DESCRIPTION
This PR updates the provider:
-  to plugin framework version 0.4.2
- creates an `_order` datasource.
- Adds the update function modified to accommodate the hashicups API /orders

