### PR TITLE
Fix Makefile NAME var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
 HOSTNAME=hashicorp.com
 NAMESPACE=edu
-NAME=hashicups
+NAME=hashicups-pf
 BINARY=terraform-provider-${NAME}
 VERSION=0.3.2
 OS_ARCH=darwin_amd64


### PR DESCRIPTION
This PR updates the Makefile

I found when running this example (with this [guide](https://learn.hashicorp.com/tutorials/terraform/plugin-framework-create?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS#build-the-provider)), `terraform plan` shows the following error.

```
│ Error: Could not load plugin
│
│
│ Plugin reinitialization required. Please run "terraform init".
│
│ Plugins are external binaries that Terraform uses to access and manipulate
│ resources. The configuration provided requires plugins which can't be located,
│ don't satisfy the version constraints, or are otherwise incompatible.
│
│ Terraform automatically discovers provider requirements from your
│ configuration, including providers used in child modules. To see the
│ requirements and constraints, run "terraform providers".
│
│ failed to instantiate provider "hashicorp.com/edu/hashicups-pf" to obtain schema: could not find executable file starting with terraform-provider-hashicups-pf
```

After updating binary name as `terraform-provider-hashicups-pf`, it works as expected