### PR TITLE
`terraform-plugin-framework` bug: `AttributePlanModifier` cannot be optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,27 @@
-.DS_Store
-vendor
+# -------------------------------------------------------------------------- Go
+# Based on: https://github.com/github/gitignore/blob/main/Go.gitignore
 
-terraform-provider-hashicups
-bin
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# ------------------------------------------------------------------- Terraform
+# Based on: https://github.com/github/gitignore/blob/main/Terraform.gitignore
 
 # Local .terraform directories
 **/.terraform/*
@@ -13,12 +32,14 @@ bin
 
 # Crash log files
 crash.log
+crash.*.log
 
-# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
-# .tfvars files are managed as part of configuration and so should be included in
-# version control.
-#
-# example.tfvars
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
@@ -28,7 +49,6 @@ override.tf.json
 *_override.tf.json
 
 # Include override files you do wish to add to version control using negated pattern
-#
 # !example_override.tf
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
@@ -37,4 +57,10 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
-terraform
+
+# Hash of providers created by "terraform init"
+.terraform.lock.hcl
+
+# -------------------------------------------------------------------- Jetbrains
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -4,15 +4,20 @@ This repo is a companion repo to the [Call APIs with Terraform Providers](https:
 
 In the collection, you will use the HashiCups provider as a bridge between Terraform and the HashiCups API. Then, extend Terraform by recreating the HashiCups provider. By the end of this collection, you will be able to take these intuitions to create your own custom Terraform provider. 
 
-## Build provider
+## Build & test the provider
 
-Run the following command to build the provider
+Run the following commands to build and test the provider
 
 ```shell
-$ go build -o terraform-provider-hashicups
+$ make build
+
+$ make test
+
+# and, for acceptance tests
+$ make testacc
 ```
 
-## Test sample configuration
+## Test `examples/` configuration
 
 First, build and install the provider.
 
@@ -20,14 +25,35 @@ First, build and install the provider.
 $ make install
 ```
 
-Then, navigate to the `examples` directory. 
+NOTE: Currently the `Makefile` is setup to `install` the built prodiver under `darwin_amd64` os/arch.
+You might need to tweak that if you are on a different system (ex. `darwin_arm64` for Apple M1 hardware).
+
+Then, launch [HashiCups](https://github.com/hashicorp-demoapp) locally, by leveraging 
+[Docker Compose](https://docs.docker.com/compose/):
+
+```shell
+$ cd docker_compose
+$ docker-compose up -d
+```
+
+NOTE: When launching this setup for the first time, there is a one time operation required - creating 
+creadentials in HashiCups. These are the cretentials that we will use when executing terraform against it.
+To create them:
+
+```shell
+curl -X POST localhost:19090/signup -d '{"username":"education", "password":"test123"}'
+```
+
+Once HashiCups is running and the user `education` is created, it's time to launch the example:
 
 ```shell
 $ cd examples
+$ terraform init
+$ terraform plan
+...
+$ terraform apply
 ```
 
-Run the following command to initialize the workspace and apply the sample configuration.
-
-```shell
-$ terraform init && terraform apply
-```
+NOTE: Every time a new build of the provider gets `make install`-ed, you will need to delete
+the `.terraform.lock.hcl` file inside the `examples/` directory. If not, `terraform` will refuse to `init` 
+because a checksum mismatch will be detected.

--- a/docker_compose/docker-compose.yml
+++ b/docker_compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   api:
-    image: "hashicorpdemoapp/product-api:v4280cf7"
+    image: "hashicorpdemoapp/product-api:v0.0.20"
     ports:
       - "19090:9090"
     volumes:
@@ -11,7 +11,8 @@ services:
     depends_on:
       - db
   db:
-    image: "hashicorpdemoapp/product-api-db:v4280cf7"
+    hostname: db
+    image: "hashicorpdemoapp/product-api-db:v0.0.20"
     ports:
       - "15432:5432"
     environment:

--- a/hashicups/models.go
+++ b/hashicups/models.go
@@ -18,9 +18,9 @@ type OrderItem struct {
 }
 
 // Coffee -
-// This Coffee struct is for Order.Items[].Coffee which does not have an 
+// This Coffee struct is for Order.Items[].Coffee which does not have an
 // ingredients field in the schema defined by plugin framework. Since the
-// resource schema must match the struct exactly (extra field will return an 
+// resource schema must match the struct exactly (extra field will return an
 // error). This struct has Ingredients commented out.
 type Coffee struct {
 	ID          int          `tfsdk:"id"`
@@ -40,22 +40,22 @@ type Ingredient struct {
 	Unit     string `tfsdk:"unit"`
 }
 
-// 
+//
 // Coffee Data Source specific structs
-// 
+//
 
 // CoffeeIngredients
 type CoffeeIngredients struct {
-	ID          int `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Teaser      types.String `tfsdk:"teaser"`
-	Description types.String `tfsdk:"description"`
-	Price       types.Number `tfsdk:"price"`
-	Image       types.String `tfsdk:"image"`
+	ID          int            `tfsdk:"id"`
+	Name        types.String   `tfsdk:"name"`
+	Teaser      types.String   `tfsdk:"teaser"`
+	Description types.String   `tfsdk:"description"`
+	Price       types.Number   `tfsdk:"price"`
+	Image       types.String   `tfsdk:"image"`
 	Ingredient  []IngredientID `tfsdk:"ingredients"`
 }
 
 // Ingredient -
 type IngredientID struct {
-	ID       int    `tfsdk:"id"`
+	ID int `tfsdk:"id"`
 }


### PR DESCRIPTION
Context: [internal slack](https://hashicorp.slack.com/archives/CTQBQ9G0Y/p1645646985756759)

## Description

_This is not a bug against this repo: this is against [terraform-plugin-framework](https://github.com/hashicorp/terraform-plugin-framework). I opened this one as I had to create a scenario to reproduce, and I used this repo to do it quickly. If confirmed, I can take care of creating the issue against the correct repo._

In this scenario, we attempt to setup an `Attribute` that is `Optional` and has a _default_ value. The value is provided a `genericDefaultValueModifier` that takes care of applying the default value `IFF` none is set.

## Expected

Terraform `plan / apply` executed as expected: if the `Optional` attribute is given a value, that value will be used. Otherwise, the default one provided by the `AttributePlanModifier`.

## Actual

Executing a `plan / apply` setting a value against the `Optional` attribute, yields a normal result: it's planned / applied as expected.

But, the following error is throw when no value is set on the same attribute:

```
╷
│ Error: Provider produced invalid plan
│
│ Provider "hashicorp.com/edu/hashicups-pf" planned an invalid value for hashicups_order.edu.unused_boolean_value: planned value cty.False for a non-computed attribute.
│
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

## Notes

I dug a bit in `terraform-plugin-framework` but I wasn't able to find which code actually throws the error, hence I couldn't dig into the logic that fails. I suspect this is something related to the protocol in `terraform-plugin-go`, but I can't be certain at this stage.
